### PR TITLE
Consistently serializing array parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ only [successfull control](http://www.w3.org/TR/html401/interact/forms.html#h-17
 
 multiselect fields with more than one value will result in an array of values in the `hash` output mode using the default hash serializer
 
+### explicit array fields
+
+Fields who's name ends with `[]` are **always** serialized as an array field in `hash` output mode using the default hash serializer.
+The field name also gets the brackets removed from its name.
+
+This does not affect `url-encoding` mode output in any way.
+
+```html
+<form id="example-form">
+	<input type="checkbox" name="foo[]" value="bar" checked />
+	<input type="checkbox" name="foo[]" value="baz" />
+	<input type="submit" value="do it!"/>
+</form>
+```
+
+```js
+var serialize = require('form-serialize');
+var form = document.querySelector('#example-form');
+
+var obj = serialize(form, { hash: true });
+// obj -> { foo: ['bar'] }
+
+var str = serialize(form);
+// str -> "foo[]=bar"
+
+```
+
 ## references
 
 This module is based on ideas from jQuery serialize and the Form.serialize method from the prototype library

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var k_r_submitter = /^(?:submit|button|image|reset|file)$/i;
 var k_r_success_contrls = /^(?:input|select|textarea|keygen)/i;
 
 // keys with brackets for hash keys
-var brackets_regex = /\[(.+?)\]/g;
+var object_brackets_regex = /\[(.+?)\]/g;
+var array_brackets_regex = /\[\]$/;
 var brackeks_prefix_regex = /^(.+?)\[/;
 
 // serializes form fields
@@ -85,6 +86,11 @@ function serialize(form, options) {
 
 // obj/hash encoding serializer
 function hash_serializer(result, key, value) {
+    var is_array_key = has_array_brackets(key);
+    if (is_array_key) {
+        key = key.replace(array_brackets_regex, '');
+    }
+
     if (key in result) {
         var existing = result[key];
         if (!Array.isArray(existing)) {
@@ -93,11 +99,11 @@ function hash_serializer(result, key, value) {
         result[key].push(value);
     }
     else {
-        if (has_brackets(key)) {
+        if (has_object_brackets(key)) {
           extract_from_brackets(result, key, value);
         }
         else {
-          result[key] = value;
+          result[key] = is_array_key ? [value] : value;
         }
     }
 
@@ -115,13 +121,17 @@ function str_serialize(result, key, value) {
     return result + (result ? '&' : '') + encodeURIComponent(key) + '=' + value;
 };
 
-function has_brackets(string) {
-  return string.match(brackets_regex);
+function has_object_brackets(string) {
+  return string.match(object_brackets_regex);
 };
 
+function has_array_brackets(string) {
+    return string.match(array_brackets_regex);
+}
+
 function matches_between_brackets(string) {
-    // Make sure to isolate brackets_regex from .exec() calls
-    var regex = new RegExp(brackets_regex);
+    // Make sure to isolate object_brackets_regex from .exec() calls
+    var regex = new RegExp(object_brackets_regex);
     var matches = [];
     var match;
 

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,27 @@ test('checkboxes', function() {
     str_check(form, 'foo=on&baz=on');
 });
 
+test('checkboxes - array', function() {
+    var form = domify('<form>' +
+        '<input type="checkbox" name="foo[]" value="bar" checked/>' +
+        '<input type="checkbox" name="foo[]" value="baz" checked/>' +
+        '</form>');
+    hash_check(form, {
+        'foo': ['bar', 'baz']
+    });
+    str_check(form, 'foo%5B%5D=bar&foo%5B%5D=baz');
+});
+
+test('checkboxes - array with single item', function() {
+    var form = domify('<form>' +
+        '<input type="checkbox" name="foo[]" value="bar" checked/>' +
+        '</form>');
+    hash_check(form, {
+        'foo': ['bar']
+    });
+    str_check(form, 'foo%5B%5D=bar');
+});
+
 test('select - single', function() {
     var form = domify('<form>' +
         '<select name="foo">' +


### PR DESCRIPTION
Hi!

This introduces the concept of parameters who's name ends with "[]" should always be treated as an array.
Prior to this change you would have to have more than one parameter with the same name to get that parameter to be serialized as an array.

See added tests for example.
