### PR TITLE
Dedupe conflicting variable names for forms with multi-select fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,9 +67,9 @@ function serialize(form, options) {
         if (element.type === 'select-multiple') {
             val = [];
 
-            var options = element.options;
-            for (var j=0 ; j<options.length ; ++j) {
-                var option = options[j];
+            var selectOptions = element.options;
+            for (var j=0 ; j<selectOptions.length ; ++j) {
+                var option = selectOptions[j];
                 if (option.selected) {
                     result = serializer(result, key, option.value);
                 }


### PR DESCRIPTION
There were two variables that were re-declared in the `if (element.type === 'select-multiple')` block:  `i` and `options`

I renamed them to `j` and `selectOptions`, respectively, to avoid conflicts.

Otherwise you start getting undesirable behavior when you're serializing a form with multi-selects. Namely the outer `i` gets incremented in the inner loop, causing the serialized form to "skip" fields.
