### PR TITLE
JSLint and global export as `formSerialize`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "form-serialize",
+  "version": "0.6.0",
+  "main": "index.js",
+  "ignore": [],
+  "authors": [
+    "Roman Shtylman <shtylman@gmail.com>",
+    "Brett Zamir <brettz9@yahoo.com>"
+  ],
+  "description": "serialize html forms",
+  "keywords": [
+    "form",
+    "serialize"
+  ],
+  "license": "MIT"
+}

--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ function serialize(form, options) {
 }
 
 if (module === undefined) {
-    window.serialize = serialize;
+    window.formSerialize = serialize;
 }
 else {
     module.exports = serialize;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
+/*jslint vars:true, continue:true*/
+var module;
+
+(function () {'use strict';
+
 // get successful control from form and assemble into object
 // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2
 
@@ -13,164 +18,15 @@ var object_brackets_regex = /\[(.+?)\]/g;
 var array_brackets_regex = /\[\]$/;
 var brackeks_prefix_regex = /^(.+?)\[/;
 
-// serializes form fields
-// @param form MUST be an HTMLForm element
-// @param options is an optional argument to configure the serialization. Default output
-// with no options specified is a url encoded string
-//    - hash: [true | false] Configure the output type. If true, the output will
-//    be a js object.
-//    - serializer: [function] Optional serializer function to override the default one.
-//    The function takes 3 arguments (result, key, value) and should return new result
-//    hash and url encoded str serializers are provided with this module
-//    - disabled: [true | false]. If true serialize disabled fields.
-//    - empty: [true | false]. If true serialize empty fields
-function serialize(form, options) {
-    if (typeof options != 'object') {
-        options = { hash: !!options };
-    }
-    else if (options.hash === undefined) {
-        options.hash = true;
-    }
-
-    var result = (options.hash) ? {} : '';
-    var serializer = options.serializer || ((options.hash) ? hash_serializer : str_serialize);
-
-    var elements = form.elements || [];
-
-    //Object store each radio and set if it's empty or not
-    var radio_store = Object.create(null);
-
-    for (var i=0 ; i<elements.length ; ++i) {
-        var element = elements[i];
-
-        // ingore disabled fields
-        if ((!options.disabled && element.disabled) || !element.name) {
-            continue;
-        }
-        // ignore anyhting that is not considered a success field
-        if (!k_r_success_contrls.test(element.nodeName) ||
-            k_r_submitter.test(element.type)) {
-            continue;
-        }
-
-        var key = element.name;
-        var val = element.value;
-
-        // we can't just use element.value for checkboxes cause some browsers lie to us
-        // they say "on" for value when the box isn't checked
-        if ((element.type === 'checkbox' || element.type === 'radio') && !element.checked) {
-            val = undefined;
-        }
-        
-        // If we want empty elements
-        if (options.empty) {
-            // for checkbox
-            if (element.type === 'checkbox' && !element.checked) {
-                val = '';
-            }
-
-            // for radio
-            if (element.type === 'radio') {
-                if (!radio_store[element.name] && !element.checked) {
-                    radio_store[element.name] = false
-                }
-                else if (element.checked) {
-                    radio_store[element.name] = true
-                }
-            }
-
-            // if options empty is true, continue only if its radio
-            if (!val && element.type == 'radio') {
-                continue;
-            }
-        }
-        else {
-            // value-less fields are ignored unless options.empty is true
-            if (!val) {
-                continue;
-            }
-        }
-
-        // multi select boxes
-        if (element.type === 'select-multiple') {
-            val = [];
-
-            var selectOptions = element.options;
-            var isSelectedOptions = false;
-            for (var j=0 ; j<selectOptions.length ; ++j) {
-                var option = selectOptions[j];
-                if (option.selected) {
-                    isSelectedOptions = true
-                    result = serializer(result, key, option.value);
-                }
-            }
-
-            // Serialize if no selected options and options.empty is true
-            if (!isSelectedOptions && options.empty) {
-                result = serializer(result, key, '');
-            }
-            
-            continue;
-        }
-        result = serializer(result, key, val);
-    }
-
-    // Check for all empty radio buttons and serialize them with key=""
-    if (options.empty) {
-        for (var key in radio_store) {
-            if (!radio_store[key]) {
-                result = serializer(result, key, '');
-            }
-        }
-    }
-
-    return result;
-}
-
-// obj/hash encoding serializer
-function hash_serializer(result, key, value) {
-    var is_array_key = has_array_brackets(key);
-    if (is_array_key) {
-        key = key.replace(array_brackets_regex, '');
-    }
-
-    if (key in result) {
-        var existing = result[key];
-        if (!Array.isArray(existing)) {
-            result[key] = [existing];
-        }
-        result[key].push(value);
-    }
-    else {
-        if (has_object_brackets(key)) {
-          extract_from_brackets(result, key, value);
-        }
-        else {
-          result[key] = is_array_key ? [value] : value;
-        }
-    }
-
-    return result;
-};
-
-// urlform encoding serializer
-function str_serialize(result, key, value) {
-    // encode newlines as \r\n cause the html spec says so
-    value = value.replace(/(\r)?\n/g, '\r\n');
-    value = encodeURIComponent(value);
-
-    // spaces should be '+' rather than '%20'.
-    value = value.replace(/%20/g, '+');
-    return result + (result ? '&' : '') + encodeURIComponent(key) + '=' + value;
-};
-
-function has_object_brackets(string) {
-  return string.match(object_brackets_regex);
-};
 
 function has_array_brackets(string) {
     return string.match(array_brackets_regex);
 }
+
+function has_object_brackets(string) {
+    return string.match(object_brackets_regex);
+}
+
 
 function matches_between_brackets(string) {
     // Make sure to isolate object_brackets_regex from .exec() calls
@@ -179,31 +35,32 @@ function matches_between_brackets(string) {
     var match;
 
     while (match = regex.exec(string)) {
-      matches.push(match[1]);
+        matches.push(match[1]);
     }
 
     return matches;
-};
+}
 
 function extract_from_brackets(result, key, value) {
     var prefix = key.match(brackeks_prefix_regex)[1];
 
     // Set the key if it doesn't exist
-    if (! result[prefix]) result[prefix] = {};
+    if (! result[prefix]) {result[prefix] = {};}
 
     var parent = result[prefix];
     var matches_between = matches_between_brackets(key);
     var length = matches_between.length;
 
-    for (var i = 0; i < length; i++) {
-        var child = matches_between[i];
-        var isLast = (length === i + 1);
+    var i, child, isLast, existing;
+    for (i = 0; i < length; i++) {
+        child = matches_between[i];
+        isLast = (length === i + 1);
 
         if (isLast) {
-            var existing = parent[child];
+            existing = parent[child];
 
             if (existing) {
-                if (! Array.isArray(existing)) {
+                if (!Array.isArray(existing)) {
                     parent[child] = [ existing ];
                 }
 
@@ -223,6 +80,166 @@ function extract_from_brackets(result, key, value) {
     }
 
     parent = value;
-};
+}
 
-module.exports = serialize;
+// obj/hash encoding serializer
+function hash_serializer(result, key, value) {
+    var is_array_key = has_array_brackets(key);
+    if (is_array_key) {
+        key = key.replace(array_brackets_regex, '');
+    }
+
+    if (key in result) {
+        var existing = result[key];
+        if (!Array.isArray(existing)) {
+            result[key] = [existing];
+        }
+        result[key].push(value);
+    }
+    else {
+        if (has_object_brackets(key)) {
+            extract_from_brackets(result, key, value);
+        }
+        else {
+            result[key] = is_array_key ? [value] : value;
+        }
+    }
+
+    return result;
+}
+
+// urlform encoding serializer
+function str_serialize(result, key, value) {
+    // encode newlines as \r\n cause the html spec says so
+    value = value.replace(/(\r)?\n/g, '\r\n');
+    value = encodeURIComponent(value);
+
+    // spaces should be '+' rather than '%20'.
+    value = value.replace(/%20/g, '+');
+    return result + (result ? '&' : '') + encodeURIComponent(key) + '=' + value;
+}
+
+// serializes form fields
+// @param form MUST be an HTMLForm element
+// @param options is an optional argument to configure the serialization. Default output
+// with no options specified is a url encoded string
+//    - hash: [true | false] Configure the output type. If true, the output will
+//    be a js object.
+//    - serializer: [function] Optional serializer function to override the default one.
+//    The function takes 3 arguments (result, key, value) and should return new result
+//    hash and url encoded str serializers are provided with this module
+//    - disabled: [true | false]. If true serialize disabled fields.
+//    - empty: [true | false]. If true serialize empty fields
+function serialize(form, options) {
+    if (typeof options !== 'object') {
+        options = { hash: !!options };
+    }
+    else if (options.hash === undefined) {
+        options.hash = true;
+    }
+
+    var result = (options.hash) ? {} : '';
+    var serializer = options.serializer || ((options.hash) ? hash_serializer : str_serialize);
+
+    var elements = form.elements || [];
+
+    //Object store each radio and set if it's empty or not
+    var radio_store = Object.create(null);
+
+    var i, j, element, key, val, option, selectOptions, isSelectedOptions;
+    for (i = 0; i < elements.length; ++i) {
+        element = elements[i];
+
+        // ingore disabled fields
+        if ((!options.disabled && element.disabled) || !element.name) {
+            continue;
+        }
+        // ignore anyhting that is not considered a success field
+        if (!k_r_success_contrls.test(element.nodeName) ||
+            k_r_submitter.test(element.type)) {
+            continue;
+        }
+
+        key = element.name;
+        val = element.value;
+
+        // we can't just use element.value for checkboxes cause some browsers lie to us
+        // they say "on" for value when the box isn't checked
+        if ((element.type === 'checkbox' || element.type === 'radio') && !element.checked) {
+            val = undefined;
+        }
+        
+        // If we want empty elements
+        if (options.empty) {
+            // for checkbox
+            if (element.type === 'checkbox' && !element.checked) {
+                val = '';
+            }
+
+            // for radio
+            if (element.type === 'radio') {
+                if (!radio_store[element.name] && !element.checked) {
+                    radio_store[element.name] = false;
+                }
+                else if (element.checked) {
+                    radio_store[element.name] = true;
+                }
+            }
+
+            // if options empty is true, continue only if its radio
+            if (!val && element.type === 'radio') {
+                continue;
+            }
+        }
+        else {
+            // value-less fields are ignored unless options.empty is true
+            if (!val) {
+                continue;
+            }
+        }
+
+        // multi select boxes
+        if (element.type === 'select-multiple') {
+            val = [];
+
+            selectOptions = element.options;
+            isSelectedOptions = false;
+            
+            for (j = 0; j < selectOptions.length; ++j) {
+                option = selectOptions[j];
+                if (option.selected) {
+                    isSelectedOptions = true;
+                    result = serializer(result, key, option.value);
+                }
+            }
+
+            // Serialize if no selected options and options.empty is true
+            if (!isSelectedOptions && options.empty) {
+                result = serializer(result, key, '');
+            }
+            
+            continue;
+        }
+        result = serializer(result, key, val);
+    }
+
+    // Check for all empty radio buttons and serialize them with key=""
+    if (options.empty) {
+        for (key in radio_store) {
+            if (!radio_store[key]) {
+                result = serializer(result, key, '');
+            }
+        }
+    }
+
+    return result;
+}
+
+if (module === undefined) {
+    window.serialize = serialize;
+}
+else {
+    module.exports = serialize;
+}
+
+}());


### PR DESCRIPTION
In case you want the PR, I improved jslint compliance (easier to check for unintended mistakes with fewer errors being reported and also follows conventions better with main function at end).

Also adds global export of `serialize` as `formSerialize` for browser usage without browserify.