### PR TITLE
Allow serializing non-HTMLForm elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Returns a serialized form of a HTMLForm element. Output is determined by the ser
 
 arg | type | desc
 :--- | :--- | :---
-form | HTMLForm | must be an HTMLForm element
+form | HTMLElement | must be an HTMLElement
 options | Object | optional options object
 
 #### options

--- a/index.js
+++ b/index.js
@@ -33,7 +33,10 @@ function serialize(form, options) {
     var result = (options.hash) ? {} : '';
     var serializer = options.serializer || ((options.hash) ? hash_serializer : str_serialize);
 
-    var elements = form && form.elements ? form.elements : [];
+    var elements = [];
+    if (form) {
+        elements = form.elements || form.querySelectorAll('input, textarea, select, button, datalist, keygen, output');
+    }
 
     //Object store each radio and set if it's empty or not
     var radio_store = Object.create(null);

--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,18 @@ test('single element', function() {
     });
 });
 
+test('single element in non-form element', function() {
+    var form = domify('<tr><input type="text" name="foo" value="bar"/></tr>');
+    hash_check(form, {
+        'foo': 'bar'
+    });
+    str_check(form, 'foo=bar');
+    empty_check(form, 'foo=bar');
+    empty_check_hash(form, {
+        'foo': 'bar'
+    });
+});
+
 test('ignore no value', function() {
     var form = domify('<form><input type="text" name="foo"/></form>');
     hash_check(form, {});


### PR DESCRIPTION
My use case here is that I have a form inside a table row, unfortunately html does not allow that so we need to have something like: `form > table > tr, tr, tr` where every `tr` is a virtual form of sorts. If I serialize the form obviously I get all trs together which isn't what I need, I just want the inputs of a given `tr` tag. The patch allows this.