### PR TITLE
Check whether the key begins with a digit

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ var k_r_success_contrls = /^(?:input|select|textarea|keygen)/i;
 // Matches bracket notation.
 var brackets = /(\[[^\[\]]*\])/g;
 
+// Matches the whole string
+function matchExact(regex, str) {
+    var match = str.match(regex);
+    return match != null && str == match[0];
+}
+
 // serializes form fields
 // @param form MUST be an HTMLForm element
 // @param options is an optional argument to configure the serialization. Default output
@@ -190,17 +196,19 @@ function hash_assign(result, keys, value) {
     }
     else {
         var string = between[1];
-        var index = parseInt(string, 10);
 
-        // If the characters between the brackets is not a number it is an
-        // attribute name and can be assigned directly.
-        if (isNaN(index)) {
-            result = result || {};
-            result[string] = hash_assign(result[string], keys, value);
-        }
-        else {
+        var isDigit = matchExact(/^\d+$/, string)
+
+        if (isDigit) {
+            var index = parseInt(string, 10);
             result = result || [];
             result[index] = hash_assign(result[index], keys, value);
+        }
+        else {
+            // If the characters between the brackets is not a number it is an
+            // attribute name and can be assigned directly.
+            result = result || {};
+            result[string] = hash_assign(result[string], keys, value);
         }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -317,6 +317,31 @@ test('bracket notation - hashes', function() {
     });
 });
 
+test('bracket notation - hashes with a digit as the first symbol in a key', function() {
+    var form = domify('<form>' +
+        '<input type="text" name="somekey[123abc][first]" value="first_value">' +
+        '<input type="text" name="somekey[123abc][second]" value="second_value">' +
+        '</form>');
+
+    hash_check(form, {
+        'somekey': {
+            '123abc': {
+                'first': 'first_value',
+                'second': 'second_value'
+            }
+        }
+    });
+
+    empty_check_hash(form, {
+        'somekey': {
+            '123abc': {
+                'first': 'first_value',
+                'second': 'second_value'
+            }
+        }
+    });
+});
+
 test('bracket notation - select multiple', function() {
     var form = domify('<form>' +
         '<select name="foo" multiple>' +


### PR DESCRIPTION
If a key begins with a digit the `hash_assign()` interprets it as an index of an array and produces the wrong key.

`1abc -> 1`

It takes place because of `parseInt()` takes the first digits and discards the rest part of `string` ([see here](https://github.com/defunctzombie/form-serialize/blob/master/index.js#L193)):

I got it with dynamically generated forms.

Here is possible solution.