### PR TITLE
use +val trick instead of parseInt to check for numeric keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '5'
 env:
   global:
   - secure: QHQz/F+IvYyRkgrVEEc3NTsfkJwXlzsU8jACVIPbhHVOaaDe97b/tk0A4vv+eo+BXVNhyio7ojLlOnlcY0eiHKc31frf/Rv4nARzdG+EmzRuBtpxsnchQ92RzKhL+hL57p0LLvTW3yPAJX44lTnI8WrbvuUA22rphm0YsD1yaLM=

--- a/index.js
+++ b/index.js
@@ -190,7 +190,10 @@ function hash_assign(result, keys, value) {
     }
     else {
         var string = between[1];
-        var index = parseInt(string, 10);
+        // +var converts the variable into a number
+        // better than parseInt because it doesn't truncate away trailing
+        // letters and actually fails if whole thing is not a number
+        var index = +string;
 
         // If the characters between the brackets is not a number it is an
         // attribute name and can be assigned directly.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "devDependencies": {
-    "domify": "~1.0.0",
-    "zuul": "~3.6.0"
+    "domify": "~1.4.0",
+    "zuul": "~3.10.1"
   },
   "scripts": {
     "test": "zuul -- test/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "zuul": "~3.6.0"
   },
   "scripts": {
-    "test": "zuul -- test/index.js"
+    "test": "zuul -- test/index.js",
+    "test-local": "zuul --local -- test/index.js"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -317,6 +317,31 @@ test('bracket notation - hashes', function() {
     });
 });
 
+test('bracket notation - hashes with a digit as the first symbol in a key', function() {
+    var form = domify('<form>' +
+        '<input type="text" name="somekey[123abc][first]" value="first_value">' +
+        '<input type="text" name="somekey[123abc][second]" value="second_value">' +
+        '</form>');
+
+    hash_check(form, {
+        'somekey': {
+            '123abc': {
+                'first': 'first_value',
+                'second': 'second_value'
+            }
+        }
+    });
+
+    empty_check_hash(form, {
+        'somekey': {
+            '123abc': {
+                'first': 'first_value',
+                'second': 'second_value'
+            }
+        }
+    });
+});
+
 test('bracket notation - select multiple', function() {
     var form = domify('<form>' +
         '<select name="foo" multiple>' +


### PR DESCRIPTION
parseInt is terrible and doesn't work as expected if input has numbers
followed by letters. It truncates the letters which is not what you
want!