### PR TITLE
Avoid sparse arrays and serialize as hash unless we have sequential arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,10 @@ function hash_assign(result, keys, value) {
 
         // If the characters between the brackets is not a number it is an
         // attribute name and can be assigned directly.
-        if (isNaN(index)) {
+        //
+        // If we process the first record and it is non-zero we assume it's a sparse array
+        // and use a hash instead of an array to avoid very large sparse arrays
+        if (isNaN(index) || (result === undefined && index !== 0)) {
             result = result || {};
             result[string] = hash_assign(result[string], keys, value);
         }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "devDependencies": {
+    "core-assert": "^0.1.3",
     "domify": "~1.4.0",
     "zuul": "~3.10.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
-var assert = require('assert');
+var assert = require('core-assert');
 var domify = require('domify');
 
 var serialize = require('../');
 
 var hash_check = function(form, exp) {
-    assert.deepEqual(serialize(form, { hash: true }), exp);
+    assert.deepStrictEqual(serialize(form, { hash: true }), exp);
 };
 
 var str_check = function(form, exp) {
@@ -12,15 +12,15 @@ var str_check = function(form, exp) {
 };
 
 var disabled_check = function(form, exp) {
-    assert.deepEqual(serialize(form, { hash : false, disabled: true }), exp);
+    assert.deepStrictEqual(serialize(form, { hash : false, disabled: true }), exp);
 };
 
 var empty_check = function(form, exp) {
-    assert.deepEqual(serialize(form, { hash : false, disabled: true, empty: true }), exp);
+    assert.deepStrictEqual(serialize(form, { hash : false, disabled: true, empty: true }), exp);
 };
 
 var empty_check_hash = function(form, exp) {
-    assert.deepEqual(serialize(form, { hash : true, disabled: true, empty: true }), exp);
+    assert.deepStrictEqual(serialize(form, { hash : true, disabled: true, empty: true }), exp);
 };
 
 test('null form', function() {
@@ -426,6 +426,20 @@ test('bracket notation - non-indexed arrays', function() {
     });
 });
 
+test('bracket notation - sparse array', function() {
+    var form = domify('<form>' +
+        '<input name="user[1234]" value="cow" />' +
+        '<input name="user[4567]" value="milk" />' +
+        '</form>');
+
+    hash_check(form, {
+        user: {
+            1234: "cow",
+            4567: "milk",
+        }
+    });
+});
+
 test('bracket notation - nested, non-indexed arrays', function() {
     var form = domify('<form>' +
         '<input name="user[tags][]" value="cow" />' +
@@ -452,6 +466,40 @@ test('bracket notation - indexed arrays', function() {
         '</form>');
 
     hash_check(form, {
+        people: {
+            0: {
+                name: "fred",
+                age: "12"
+            },
+            1: {
+                name: "bob",
+                age: "14"
+            },
+            2: {
+                name: "bubba",
+                age: "15"
+            },
+            3: {
+                age: "2"
+            },
+            _values: [
+                {name: "frank"}
+            ]
+        }
+    });
+});
+
+test('bracket notation - ordered indexed arrays', function() {
+    var form = domify('<form>' +
+        '<input name="people[0][name]" value="fred" />' +
+        '<input name="people[0][age]" value="12" />' +
+        '<input name="people[1][name]" value="bob" />' +
+        '<input name="people[1][age]" value="14" />' +
+        '<input name="people[][name]" value="frank">' +
+        '<input name="people[2][age]" value="2">' +
+        '</form>');
+
+    hash_check(form, {
         people: [
             {
                 name: "fred",
@@ -460,10 +508,6 @@ test('bracket notation - indexed arrays', function() {
             {
                 name: "bob",
                 age: "14"
-            },
-            {
-                name: "bubba",
-                age: "15"
             },
             {
                 name: "frank",


### PR DESCRIPTION
The upgrade to 0.7 and the new hash support for arrays broke our usage because we use numeric ids as part of arrays e.g. `<input name="stuff[1203843]">`. We then end up with *very* large arrays that cause UI locks further down as they end up being iterated over  and trigger millions of iterations over undefined values. With objects we can iterate over the keys just fine and nothing breaks.

I tried to limit the changes but obviously it's impossible to fix this use case without changing others.