### PR TITLE
Allow to normalize input values

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ option | type | default | desc
 :--- | :--- | :---: | :---
 hash | boolean | false | if `true`, the hash serializer will be used for `serializer` option
 serializer | function | url-encoding | override the default serializer (hash or url-encoding)
+normalizer | function | undefined | override the value of the serialized form
 disabled | boolean | false | if `true`, disabled fields will also be serialized
 empty | boolean | false | if `true`, empty fields will also be serialized
 
@@ -56,6 +57,34 @@ empty | boolean | false | if `true`, empty fields will also be serialized
 Serializers take 3 arguments: `result`, `key`, `value` and should return a newly updated result.
 
 See the example serializers in the index.js source file.
+
+### normalizer
+
+Normalizer take 2 arguments: `val` and `element` and should return a newly updated value.
+
+```html
+<form id="example-form">
+	<input type="text" name="foo" value="bar"/>
+	<input type="number" name="baz" value="1"/>
+	<input type="submit" value="do it!"/>
+</form>
+```
+
+```js
+var serialize = require('form-serialize');
+var form = document.querySelector('#example-form');
+
+var obj = serialize(form, {
+    hash:true,
+    normalizer: function(val, element) {
+      if (element.type != 'number') {
+        return val;
+      } else {
+        return parseInt(val, 10);
+      }
+});
+// obj -> { foo: 'bar', baz: 1 }
+```
 
 ## notes
 

--- a/index.js
+++ b/index.js
@@ -124,6 +124,10 @@ function serialize(form, options) {
             continue;
         }
 
+        if (options.normalizer) {
+            val = options.normalizer(val, element);
+        }
+
         result = serializer(result, key, val);
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -499,3 +499,18 @@ test('custom serializer', function() {
     "node": "ZUUL"
   });
 });
+
+test('normalizer', function() {
+  var form = domify('<form><input type="number" name="foo" value="1" /></form>');
+
+  assert.strictEqual(serialize(form, {
+    hash:true,
+    normalizer: function(val, element) {
+      if (element.type != 'number') {
+        return val;
+      } else {
+        return parseInt(val, 10);
+      }
+    }
+  }).foo, 1);
+});


### PR DESCRIPTION
The current implementation always serialize the form values as string. This is not always convenient if your backend only accept well defined type (e.g. boolean for checkbox instead of `on`/`off` or timestamp for dates).

Actually, to bypass this, one must either: 
* Rewrite the whole hash serializer
* Serialize the form and then map recursively on the result

This PR allow to pass, in a similar fashion to `serializer` a function `normalizer` (this name might need some bikeshed, as it's maybe not that obvious) which allow to override the return value of the input.

This might not be a good fit for the project, so feel free to fire at will.