### PR TITLE
Serialize properly radio input with empty value

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function serialize(form, options) {
             }
 
             // if options empty is true, continue only if its radio
-            if (!val && element.type == 'radio') {
+            if (val == undefined && element.type == 'radio') {
                 continue;
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -256,6 +256,19 @@ test('radio - single default', function() {
     });
 });
 
+test('radio - empty value', function() {
+    var form = domify('<form>' +
+        '<input type="radio" name="foo" value="" checked="checked"/>' +
+        '<input type="radio" name="foo" value="bar2"/>' +
+        '</form>');
+    hash_check(form, {});
+    str_check(form, '');
+    empty_check(form, 'foo=');
+    empty_check_hash(form, {
+        'foo':''
+    });
+});
+
 // in this case the radio buttons and checkboxes share a name key
 // the checkbox value should still be honored
 test('radio w/checkbox', function() {


### PR DESCRIPTION
Found this edge-case caused by type coercion. Not critical but I thought it was worth to fix for the sake of consistency.