### PR TITLE
Set value of empty checkbox to 'false' rather than quote

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ function serialize(form, options) {
         // If we want empty elements
         if (options.empty) {
             // for checkbox
-            if (element.type === 'checkbox' && !element.checked) {
-                val = '';
+            if (element.type === 'checkbox') {
+                val = element.checked;
             }
 
             // for radio


### PR DESCRIPTION
Most API input validation would prefer a `true` or `false` to empty quotes for checkboxes